### PR TITLE
Use original field names for struct 'json:X' annotations

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -331,14 +331,13 @@ export class GolangGenerator {
               }
               w.push('struct {')
             } else {
-              w.push(`string \`json:"${name}"\``)
+              w.push(`string \`json:"${field.name.value}"\``)
             }
             l.push(w.join(''))
           },
           leave: field => {
             if (field.selectionSet) {
-              const name = this.formatName(field.name.value)
-              l.push(`} \`json:"${name}"\``)
+              l.push(`} \`json:"${field.name.value}"\``)
             }
           },
         },


### PR DESCRIPTION
If a graphql command or fields contain underscores (e.g. snake_case), the generator currently converts both the Go struct field names AND the json annotations to PascalCase. In the process, this removes the underscores, which are significant to the query. For example, the following GraphQL query definition...:
```
query GetExporter($tenant: String!, $name: String!) {
  exporter_by_pk(tenant: $tenant, name: $name) {
    tenant
    name
    type
    credential
    config
    created_at
    updated_at
  }
}
```

...is rendered to Go like this:
```
type GetExporterResponse struct {
	ExporterByPk struct {
		Tenant     string `json:"Tenant"`
		Name       string `json:"Name"`
		Type       string `json:"Type"`
		Credential string `json:"Credential"`
		Config     string `json:"Config"`
		CreatedAt  string `json:"CreatedAt"` // was created_at
		UpdatedAt  string `json:"UpdatedAt"` // was updated_at
	} `json:"ExporterByPk"` // was exporter_by_pk
}
```

With this PR, the issue is resolved by using the original names in the `json:X` annotations, while keeping the PascalCase for the Go field names themselves:
```
type GetExporterResponse struct {
	ExporterByPk struct {
		Tenant     string `json:"tenant"`
		Name       string `json:"name"`
		Type       string `json:"type"`
		Credential string `json:"credential"`
		Config     string `json:"config"`
		CreatedAt  string `json:"created_at"` // fixed
		UpdatedAt  string `json:"updated_at"` // fixed
	} `json:"exporter_by_pk"` // fixed
}
```